### PR TITLE
BUG: fix restore pod naming collision by appending timestamp

### DIFF
--- a/scripts/migration/single-migration.sh
+++ b/scripts/migration/single-migration.sh
@@ -295,7 +295,7 @@ buildah rm $newcontainer || handle_error "Failed to remove new container"
 
 log "-- Pushing image \"$checkpoint_image_name:checkpoint\" to local registry --"
 # Step 6: Push the image to local registry
-buildah push --tls-verify=false localhost/$checkpoint_image_name:checkpoint 10.0.0.180:5000/$checkpoint_image_name:checkpoint || handle_error "Failed to push image to local registry"
+buildah push --tls-verify=false localhost/$checkpoint_image_name:checkpoint 127.0.0.1:5000/$checkpoint_image_name:checkpoint || handle_error "Failed to push image to local registry"
 pushImageTime=$(($(date +%s%3N) - $startTime))
 
 log "-- Image pushed onto local registy --"
@@ -309,9 +309,14 @@ kubectl config set-context --current --namespace="$namespace"
 log "-- Applying restore yaml file --"
 
 startTime=$(date +%s%3N)
-kubectl apply -f /home/ubuntu/meierm78/CubeMig/scripts/migration/yaml/restore_$containerName.yaml || handle_error "Failed to apply restore yaml file"
+timestampSuffix=$(date +"%Y%m%d-%H%M%S")
+newPodName="${containerName}-restore-${timestampSuffix}"
+newPodName="${newPodName:0:63}"
+restoreTemplate="/home/ubuntu/teemig/CubeMig/scripts/migration/yaml/restore_${containerName}.yaml"
+restoreManifest="${log_dir}/restore_${newPodName}.yaml"
 
-newPodName=$containerName-restore
+sed "s/${containerName}-restore/${newPodName}/g" "$restoreTemplate" > "$restoreManifest" || handle_error "Failed to generate restore yaml file"
+kubectl apply -f "$restoreManifest" || handle_error "Failed to apply restore yaml file"
 
 log "-- Waiting for the new pod \"$newPodName\" to be ready --"
 # Wait with timeout to allow for image pulling and startup
@@ -326,7 +331,7 @@ if kubectl wait --for=jsonpath='{.status.phase}'=Running pod/$newPodName --timeo
       kubectl patch virtualservice "$appName" --type='json' -p='[
         {
           "op": "replace",
-          "path": "/spec/http/0/mirror/subset",
+          "path": "/spec/http/0/mirrors/0/destination/subset",
           "value": "v2-monitor"
         }
       ]' || handle_error "Failed to redirect mirrored traffic to new app"
@@ -374,8 +379,8 @@ log "-- Performance summary created --"
 
 if [ "$forensicAnalysis" == true ]; then
   log "-- Performing forensic analysis --"
-  sudo chmod 770 /home/ubuntu/meierm78/CubeMig/scripts/utils/forensic_analysis/forensic_analysis.sh
-  /home/ubuntu/meierm78/CubeMig/scripts/utils/forensic_analysis/forensic_analysis.sh "$checkpointfile" "$log_dir" || handle_error "Failed to perform forensic analysis"
+  sudo chmod 770 /home/ubuntu/teemig/CubeMig/scripts/utils/forensic_analysis/forensic_analysis.sh
+  /home/ubuntu/teemig/CubeMig/scripts/utils/forensic_analysis/forensic_analysis.sh "$checkpointfile" "$log_dir" || handle_error "Failed to perform forensic analysis"
   log "-- Forensic analysis complete --"
 fi
 

--- a/scripts/migration/single-migration.sh.backup
+++ b/scripts/migration/single-migration.sh.backup
@@ -28,7 +28,7 @@ if [ -z "$podName" ]; then
     exit 1
 fi
 
-source /home/ubuntu/meierm78/ContMigration-VT1/scripts/migration/.env
+source /home/ubuntu/ContMigration-VT1/scripts/migration/.env
 
 # Function to log messages
 log() {
@@ -285,9 +285,14 @@ kubectl config use-context $destCluster || handle_error "Failed to switch contex
 log "-- Applying restore yaml file --"
 
 startTime=$(date +%s%3N)
-kubectl apply -f /home/ubuntu/meierm78/ContMigration-VT1/scripts/migration/yaml/restore_$appName.yaml || handle_error "Failed to apply restore yaml file"
+timestampSuffix=$(date +"%Y%m%d-%H%M%S")
+newPodName="${appName}-restore-${timestampSuffix}"
+newPodName="${newPodName:0:63}"
+restoreTemplate="/home/ubuntu/ContMigration-VT1/scripts/migration/yaml/restore_${appName}.yaml"
+restoreManifest="${log_dir}/restore_${newPodName}.yaml"
 
-newPodName=$appName-restore
+sed "s/${appName}-restore/${newPodName}/g" "$restoreTemplate" > "$restoreManifest" || handle_error "Failed to generate restore yaml file"
+kubectl apply -f "$restoreManifest" || handle_error "Failed to apply restore yaml file"
 
 log "-- Waiting for the new pod \"$newPodName\" to be ready --"
 # Wait with timeout to allow for image pulling and startup
@@ -320,8 +325,8 @@ log "-- Performance summary created --"
 
 if [ "$forensicAnalysis" == true ]; then
   log "-- Performing forensic analysis --"
-  sudo chmod 770 /home/ubuntu/meierm78/ContMigration-VT1/scripts/utils/forensic_analysis/forensic_analysis.sh
-  /home/ubuntu/meierm78/ContMigration-VT1/scripts/utils/forensic_analysis/forensic_analysis.sh "$checkpointfile" "$log_dir" || handle_error "Failed to perform forensic analysis"
+  sudo chmod 770 /home/ubuntu/ContMigration-VT1/scripts/utils/forensic_analysis/forensic_analysis.sh
+  /home/ubuntu/ContMigration-VT1/scripts/utils/forensic_analysis/forensic_analysis.sh "$checkpointfile" "$log_dir" || handle_error "Failed to perform forensic analysis"
   log "-- Forensic analysis complete --"
 fi
 


### PR DESCRIPTION
## Summary
This PR fixes migration runs that could report success even when an old target restore pod was reused.
Main changes:
- Generate a unique target restore pod name per run using timestamp suffix:
  - `<container>-restore-YYYYMMDD-HHMMSS`
- Generate a per-run restore manifest and apply that file instead of reusing static restore naming.
- Wait for the newly generated restore pod name to reach `Running`.

Additional script corrections included in this branch:
- Fix Istio patch path for mirror subset:
  - `/spec/http/0/mirror/subset` -> `/spec/http/0/mirrors/0/destination/subset`
- Update hardcoded local paths (`/home/ubuntu/meierm78/...` -> correct workspace paths).
- Update local registry push target in `single-migration.sh` to `127.0.0.1:5000`.

## Problem
With static restore pod names (`...-restore`), `kubectl apply` could reuse an already existing pod in target cluster.
That caused false-positive migration completion (old pod still running, no fresh restore pod created).

## Impact
- Prevents restore pod name collisions on target cluster.
- Makes each migration run deterministic and traceable.
- Reduces false-success outcomes in migration workflow.
